### PR TITLE
Renaming device_state_attributes to extra_state_attributes to follow upstream changes

### DIFF
--- a/custom_components/antistorm/binary_sensor.py
+++ b/custom_components/antistorm/binary_sensor.py
@@ -61,7 +61,7 @@ class AntistormBinarySensor(BinarySensorEntity):
         self._name = SENSOR_TYPES[sensor_type][1]
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         output = dict()
         output[ATTR_ATTRIBUTION] = ATTRIBUTION
         return output

--- a/custom_components/antistorm/sensor.py
+++ b/custom_components/antistorm/sensor.py
@@ -60,7 +60,7 @@ class AntistormSensor(Entity):
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][2]
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         output = dict()
         output[ATTR_ATTRIBUTION] = ATTRIBUTION
         return output


### PR DESCRIPTION
HA 2021.12.0 introduced some warnings:

>  Logger: homeassistant.helpers.entity
> Source: helpers/entity.py:549
> First occurred: 21:33:59 (4 occurrences)
> Last logged: 21:33:59
> 
>     Entity sensor.antistorm_135_storm_probability (<class 'custom_components.antistorm.sensor.AntistormSensor'>) implements device_state_attributes. Please report it to the custom component author.
>     Entity sensor.antistorm_135_storm_time (<class 'custom_components.antistorm.sensor.AntistormSensor'>) implements device_state_attributes. Please report it to the custom component author.
>     Entity sensor.antistorm_135_rain_probability (<class 'custom_components.antistorm.sensor.AntistormSensor'>) implements device_state_attributes. Please report it to the custom component author.
>     Entity sensor.antistorm_135_rain_time (<class 'custom_components.antistorm.sensor.AntistormSensor'>) implements device_state_attributes. Please report it to the custom component author.

Apparently it is due to this change: https://github.com/home-assistant/core/pull/47304
 
So that's the reason for this cosmetic PR. As far as I understand this simple rename is all there is to it. It works on my setup.